### PR TITLE
Alterando os testes: deveFalharAoCriarCategoriaComCamposNulos e deveF…

### DIFF
--- a/src/test/java/com/math012/crudpostgressql/business/service/CategoriasServiceTest.java
+++ b/src/test/java/com/math012/crudpostgressql/business/service/CategoriasServiceTest.java
@@ -71,7 +71,7 @@ public class CategoriasServiceTest {
         RequestException requestException = assertThrows(RequestException.class,()->{
             service.criarCategoria(categoriasRequestDTONulo);
         });
-        assertEquals("Erro ao salvar o produto: campos inválidos",requestException.getMessage());
+        assertEquals("Erro ao salvar a categoria: campos inválidos",requestException.getMessage());
     }
 
     @Test
@@ -79,7 +79,7 @@ public class CategoriasServiceTest {
         RequestException requestException = assertThrows(RequestException.class,()->{
             service.criarCategoria(categoriasRequestDTOVazio);
         });
-        assertEquals("Erro ao salvar o produto: campos inválidos",requestException.getMessage());
+        assertEquals("Erro ao salvar a categoria: campos inválidos",requestException.getMessage());
     }
 
     @Test


### PR DESCRIPTION
…alharAoCriarCategoriaComCamposVazios para retornar a resposta adequada.